### PR TITLE
Update driver for newer kernels

### DIFF
--- a/apple-ib-als.c
+++ b/apple-ib-als.c
@@ -460,7 +460,7 @@ static int appleals_config_iio(struct appleals_device *als_dev)
 	struct appleals_device **priv;
 	int rc;
 
-	iio_dev = iio_device_alloc(sizeof(als_dev));
+       iio_dev = iio_device_alloc(&als_dev->hid_dev->dev, sizeof(als_dev));
 	if (!iio_dev)
 		return -ENOMEM;
 
@@ -482,7 +482,9 @@ static int appleals_config_iio(struct appleals_device *als_dev)
 		goto free_iio_dev;
 	}
 
-	iio_trig = iio_trigger_alloc("%s-dev%d", iio_dev->name, iio_dev->id);
+       iio_trig = iio_trigger_alloc(&als_dev->hid_dev->dev,
+                                    "%s-%s", iio_dev->name,
+                                    dev_name(&als_dev->hid_dev->dev));
 	if (!iio_trig) {
 		rc = -ENOMEM;
 		goto clean_trig_buf;

--- a/apple-ibridge.c
+++ b/apple-ibridge.c
@@ -843,13 +843,11 @@ static int appleib_probe(struct acpi_device *acpi)
 	return 0;
 }
 
-static int appleib_remove(struct acpi_device *acpi)
+static void appleib_remove(struct acpi_device *acpi)
 {
 	struct appleib_device *ib_dev = acpi_driver_data(acpi);
 
-	hid_unregister_driver(&ib_dev->ib_driver);
-
-	return 0;
+       hid_unregister_driver(&ib_dev->ib_driver);
 }
 
 static int appleib_suspend(struct device *dev)

--- a/applespi.c
+++ b/applespi.c
@@ -587,7 +587,8 @@ static void applespi_setup_read_txfrs(struct applespi_data *applespi)
 	memset(dl_t, 0, sizeof(*dl_t));
 	memset(rd_t, 0, sizeof(*rd_t));
 
-	dl_t->delay_usecs = applespi->spi_settings.spi_cs_delay;
+       dl_t->delay.value = applespi->spi_settings.spi_cs_delay;
+       dl_t->delay.unit  = SPI_DELAY_UNIT_USECS;
 
 	rd_t->rx_buf = applespi->rx_buffer;
 	rd_t->len = APPLESPI_PACKET_SIZE;
@@ -616,14 +617,17 @@ static void applespi_setup_write_txfrs(struct applespi_data *applespi)
 	 * end up with an extra unnecessary (but harmless) cs assertion and
 	 * deassertion.
 	 */
-	wt_t->delay_usecs = SPI_RW_CHG_DELAY_US;
+       wt_t->delay.value = SPI_RW_CHG_DELAY_US;
+       wt_t->delay.unit  = SPI_DELAY_UNIT_USECS;
 	wt_t->cs_change = 1;
 
-	dl_t->delay_usecs = applespi->spi_settings.spi_cs_delay;
+       dl_t->delay.value = applespi->spi_settings.spi_cs_delay;
+       dl_t->delay.unit  = SPI_DELAY_UNIT_USECS;
 
 	wr_t->tx_buf = applespi->tx_buffer;
 	wr_t->len = APPLESPI_PACKET_SIZE;
-	wr_t->delay_usecs = SPI_RW_CHG_DELAY_US;
+       wr_t->delay.value = SPI_RW_CHG_DELAY_US;
+       wr_t->delay.unit  = SPI_DELAY_UNIT_USECS;
 
 	st_t->rx_buf = applespi->tx_status;
 	st_t->len = APPLESPI_STATUS_SIZE;
@@ -1786,52 +1790,42 @@ static u32 applespi_notify(acpi_handle gpe_device, u32 gpe, void *context)
 
 static int applespi_get_saved_bl_level(struct applespi_data *applespi)
 {
-	struct efivar_entry *efivar_entry;
-	u16 efi_data = 0;
-	unsigned long efi_data_len;
-	int sts;
+       efi_guid_t guid = EFI_BL_LEVEL_GUID;
+       unsigned long len = sizeof(u16);
+       u16 data = 0;
+       u32 attr;
+       efi_status_t status;
+       int err;
 
-	efivar_entry = kmalloc(sizeof(*efivar_entry), GFP_KERNEL);
-	if (!efivar_entry)
-		return -ENOMEM;
+       status = efivar_get_variable((efi_char16_t *)EFI_BL_LEVEL_NAME, &guid,
+                                   &attr, &len, &data);
+       if (status == EFI_NOT_FOUND)
+               return -ENOENT;
 
-	memcpy(efivar_entry->var.VariableName, EFI_BL_LEVEL_NAME,
-	       sizeof(EFI_BL_LEVEL_NAME));
-	efivar_entry->var.VendorGuid = EFI_BL_LEVEL_GUID;
-	efi_data_len = sizeof(efi_data);
+       err = efi_status_to_err(status);
+       if (err)
+               dev_warn(&applespi->spi->dev,
+                        "Error getting backlight level from EFI vars: %d\n",
+                        err);
 
-	sts = efivar_entry_get(efivar_entry, NULL, &efi_data_len, &efi_data);
-	if (sts && sts != -ENOENT)
-		dev_warn(&applespi->spi->dev,
-			 "Error getting backlight level from EFI vars: %d\n",
-			 sts);
-
-	kfree(efivar_entry);
-
-	return sts ? sts : efi_data;
+       return err ? err : data;
 }
 
 static void applespi_save_bl_level(struct applespi_data *applespi,
-				   unsigned int level)
+                                   unsigned int level)
 {
-	efi_guid_t efi_guid;
-	u32 efi_attr;
-	unsigned long efi_data_len;
-	u16 efi_data;
-	int sts;
+       efi_guid_t guid = EFI_BL_LEVEL_GUID;
+       u16 data = (u16)level;
+       u32 attr = EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_BOOTSERVICE_ACCESS |
+                  EFI_VARIABLE_RUNTIME_ACCESS;
+       efi_status_t status;
 
-	/* Save keyboard backlight level */
-	efi_guid = EFI_BL_LEVEL_GUID;
-	efi_data = (u16)level;
-	efi_data_len = sizeof(efi_data);
-	efi_attr = EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_BOOTSERVICE_ACCESS |
-		   EFI_VARIABLE_RUNTIME_ACCESS;
-
-	sts = efivar_entry_set_safe((efi_char16_t *)EFI_BL_LEVEL_NAME, efi_guid,
-				    efi_attr, true, efi_data_len, &efi_data);
-	if (sts)
-		dev_warn(&applespi->spi->dev,
-			 "Error saving backlight level to EFI vars: %d\n", sts);
+       status = efivar_set_variable((efi_char16_t *)EFI_BL_LEVEL_NAME, &guid,
+                                    attr, sizeof(data), &data);
+       if (status != EFI_SUCCESS)
+               dev_warn(&applespi->spi->dev,
+                        "Error saving backlight level to EFI vars: %d\n",
+                        efi_status_to_err(status));
 }
 
 static void applespi_enable_early_event_tracing(struct device *dev)
@@ -2109,7 +2103,7 @@ static void applespi_drain_reads(struct applespi_data *applespi)
 	spin_unlock_irqrestore(&applespi->cmd_msg_lock, flags);
 }
 
-static int applespi_remove(struct spi_device *spi)
+static void applespi_remove(struct spi_device *spi)
 {
 	struct applespi_data *applespi = spi_get_drvdata(spi);
 
@@ -2121,9 +2115,7 @@ static int applespi_remove(struct spi_device *spi)
 
 	applespi_drain_reads(applespi);
 
-	debugfs_remove_recursive(applespi->debugfs_root);
-
-	return 0;
+       debugfs_remove_recursive(applespi->debugfs_root);
 }
 
 static void applespi_shutdown(struct spi_device *spi)
@@ -2633,3 +2625,4 @@ MODULE_LICENSE("GPL v2");
 MODULE_DESCRIPTION("MacBook(Pro) SPI Keyboard/Touchpad driver");
 MODULE_AUTHOR("Federico Lorenzi");
 MODULE_AUTHOR("Ronald Tschalär");
+MODULE_IMPORT_NS(EFIVAR);


### PR DESCRIPTION
## Summary
- adjust IIO device and trigger creation to match modern API
- fix acpi driver remove callback signature
- update SPI transfer delay fields for modern `struct spi_transfer`
- rework EFI variable handling using `efivar_get_variable`/`efivar_set_variable`
- import EFIVAR namespace

## Testing
- `make KVERSION=6.8.0-60-generic`

------
https://chatgpt.com/codex/tasks/task_e_685101775e04832189e8fd000090b795