### PR TITLE
Update drivers for kernel 6.11

### DIFF
--- a/apple-ib-als.c
+++ b/apple-ib-als.c
@@ -460,7 +460,7 @@ static int appleals_config_iio(struct appleals_device *als_dev)
 	struct appleals_device **priv;
 	int rc;
 
-	iio_dev = iio_device_alloc(sizeof(als_dev));
+       iio_dev = iio_device_alloc(&als_dev->hid_dev->dev, sizeof(*als_dev));
 	if (!iio_dev)
 		return -ENOMEM;
 
@@ -482,7 +482,8 @@ static int appleals_config_iio(struct appleals_device *als_dev)
 		goto free_iio_dev;
 	}
 
-	iio_trig = iio_trigger_alloc("%s-dev%d", iio_dev->name, iio_dev->id);
+        iio_trig = iio_trigger_alloc(&als_dev->hid_dev->dev, "%s-dev%d", iio_dev->name,
+                                    iio_device_id(iio_dev));
 	if (!iio_trig) {
 		rc = -ENOMEM;
 		goto clean_trig_buf;
@@ -631,23 +632,18 @@ error:
 	return rc;
 }
 
-static int appleals_platform_remove(struct platform_device *pdev)
+static void appleals_platform_remove(struct platform_device *pdev)
 {
-	struct appleib_device_data *ddata = pdev->dev.platform_data;
-	struct appleib_device *ib_dev = ddata->ib_dev;
-	struct appleals_device *als_dev = platform_get_drvdata(pdev);
-	int rc;
+        struct appleib_device_data *ddata = pdev->dev.platform_data;
+        struct appleib_device *ib_dev = ddata->ib_dev;
+        struct appleals_device *als_dev = platform_get_drvdata(pdev);
+        int rc;
 
-	rc = appleib_unregister_hid_driver(ib_dev, &appleals_hid_driver);
-	if (rc)
-		goto error;
+        rc = appleib_unregister_hid_driver(ib_dev, &appleals_hid_driver);
+        if (rc)
+                return;
 
-	kfree(als_dev);
-
-	return 0;
-
-error:
-	return rc;
+        kfree(als_dev);
 }
 
 static const struct platform_device_id appleals_platform_ids[] = {
@@ -662,7 +658,7 @@ static struct platform_driver appleals_platform_driver = {
 		.name	= "apple-ib-als",
 	},
 	.probe = appleals_platform_probe,
-	.remove = appleals_platform_remove,
+        .remove_new = appleals_platform_remove,
 };
 
 module_platform_driver(appleals_platform_driver);

--- a/apple-ib-tb.c
+++ b/apple-ib-tb.c
@@ -1259,23 +1259,16 @@ error:
 	return rc;
 }
 
-static int appletb_platform_remove(struct platform_device *pdev)
+static void appletb_platform_remove(struct platform_device *pdev)
 {
-	struct appleib_device_data *ddata = pdev->dev.platform_data;
-	struct appleib_device *ib_dev = ddata->ib_dev;
-	struct appletb_device *tb_dev = platform_get_drvdata(pdev);
-	int rc;
+        struct appleib_device_data *ddata = pdev->dev.platform_data;
+        struct appleib_device *ib_dev = ddata->ib_dev;
+        struct appletb_device *tb_dev = platform_get_drvdata(pdev);
 
-	rc = appleib_unregister_hid_driver(ib_dev, &appletb_hid_driver);
-	if (rc)
-		goto error;
+        if (appleib_unregister_hid_driver(ib_dev, &appletb_hid_driver))
+                return;
 
-	appletb_free_device(tb_dev);
-
-	return 0;
-
-error:
-	return rc;
+        appletb_free_device(tb_dev);
 }
 
 static const struct platform_device_id appletb_platform_ids[] = {
@@ -1290,7 +1283,7 @@ static struct platform_driver appletb_platform_driver = {
 		.name	= "apple-ib-tb",
 	},
 	.probe = appletb_platform_probe,
-	.remove = appletb_platform_remove,
+        .remove_new = appletb_platform_remove,
 };
 
 module_platform_driver(appletb_platform_driver);

--- a/apple-ib-tb.c
+++ b/apple-ib-tb.c
@@ -946,14 +946,19 @@ static int appletb_fill_report_info(struct appletb_device *tb_dev,
 	report_info->usb_epnum = 0;
 
 	report_info->report_id = field->report->id;
-	switch (field->report->type) {
-	case HID_INPUT_REPORT:
-		report_info->report_type = 0x01; break;
-	case HID_OUTPUT_REPORT:
-		report_info->report_type = 0x02; break;
-	case HID_FEATURE_REPORT:
-		report_info->report_type = 0x03; break;
-	}
+       switch (field->report->type) {
+       case HID_INPUT_REPORT:
+               report_info->report_type = 0x01;
+               break;
+       case HID_OUTPUT_REPORT:
+               report_info->report_type = 0x02;
+               break;
+       case HID_FEATURE_REPORT:
+               report_info->report_type = 0x03;
+               break;
+       default:
+               break;
+       }
 
 	return 1;
 }

--- a/apple-ibridge.c
+++ b/apple-ibridge.c
@@ -64,7 +64,6 @@
 #else
 #define	hid_to_usb_dev(hid_dev) \
 	to_usb_device((hid_dev)->dev.parent->parent)
-#endif
 
 #define USB_ID_VENDOR_APPLE	0x05ac
 #define USB_ID_PRODUCT_IBRIDGE	0x8600
@@ -585,10 +584,8 @@ struct hid_field *appleib_find_hid_field(struct hid_device *hdev,
 		struct list_head *report_list =
 			    &hdev->report_enum[report_types[t]].report_list;
 		list_for_each_entry(report, report_list, list) {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 18, 0)
 			if (report->application != application)
 				continue;
-#endif
 
 			field = appleib_find_report_field(report, field_usage);
 			if (field)

--- a/apple-ibridge.c
+++ b/apple-ibridge.c
@@ -64,6 +64,7 @@
 #else
 #define	hid_to_usb_dev(hid_dev) \
 	to_usb_device((hid_dev)->dev.parent->parent)
+#endif
 
 #define USB_ID_VENDOR_APPLE	0x05ac
 #define USB_ID_PRODUCT_IBRIDGE	0x8600

--- a/apple-ibridge.c
+++ b/apple-ibridge.c
@@ -189,8 +189,8 @@ static void appleib_remove_device(struct appleib_device *ib_dev,
 	kfree(dev_info);
 }
 
-void appleib_detach_and_free_hid_driver(struct appleib_device *ib_dev,
-					struct appleib_hid_drv_info *drv_info)
+static void appleib_detach_and_free_hid_driver(struct appleib_device *ib_dev,
+                                        struct appleib_hid_drv_info *drv_info)
 {
 	appleib_detach_devices(ib_dev, drv_info->driver);
 	list_del_rcu(&drv_info->entry);
@@ -843,13 +843,11 @@ static int appleib_probe(struct acpi_device *acpi)
 	return 0;
 }
 
-static int appleib_remove(struct acpi_device *acpi)
+static void appleib_remove(struct acpi_device *acpi)
 {
-	struct appleib_device *ib_dev = acpi_driver_data(acpi);
+        struct appleib_device *ib_dev = acpi_driver_data(acpi);
 
-	hid_unregister_driver(&ib_dev->ib_driver);
-
-	return 0;
+        hid_unregister_driver(&ib_dev->ib_driver);
 }
 
 static int appleib_suspend(struct device *dev)
@@ -898,7 +896,6 @@ MODULE_DEVICE_TABLE(acpi, appleib_acpi_match);
 static struct acpi_driver appleib_driver = {
 	.name		= "apple-ibridge",
 	.class		= "topcase", /* ? */
-	.owner		= THIS_MODULE,
 	.ids		= appleib_acpi_match,
 	.ops		= {
 		.add		= appleib_probe,

--- a/applespi.c
+++ b/applespi.c
@@ -67,13 +67,6 @@
 #include "applespi.h"
 #include "applespi_trace.h"
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 0)
-#define PRE_SPI_PROPERTIES
-#endif
-
-#ifdef PRE_SPI_PROPERTIES
-#include <linux/notifier.h>
-#endif
 
 #ifndef sizeof_field
 #define sizeof_field(TYPE, MEMBER)	sizeof((((TYPE *)0)->MEMBER))
@@ -373,14 +366,7 @@ struct spi_packet {
 };
 
 struct spi_settings {
-#ifdef PRE_SPI_PROPERTIES
-	u64	spi_sclk_period;	/* period in ns */
-	u64	spi_word_size;		/* in number of bits */
-	u64	spi_bit_order;		/* 1 = MSB_FIRST, 0 = LSB_FIRST */
-	u64	spi_spo;		/* clock polarity: 0 = low, 1 = high */
-	u64	spi_sph;		/* clock phase: 0 = first, 1 = second */
-#endif
-	u64	spi_cs_delay;		/* cs-to-clk delay in us */
+    u64     spi_cs_delay;		/* cs-to-clk delay in us */
 	u64	reset_a2r_usec;		/* active-to-receive delay? */
 	u64	reset_rec_usec;		/* ? (cur val: 10) */
 };
@@ -722,7 +708,6 @@ static inline bool applespi_check_write_status(struct applespi_data *applespi,
 	return true;
 }
 
-#ifdef PRE_SPI_PROPERTIES
 
 struct appleacpi_spi_registration_info {
 	struct class_interface	cif;
@@ -733,108 +718,11 @@ struct appleacpi_spi_registration_info {
 	struct notifier_block	slave_notifier;
 };
 
-struct applespi_acpi_map_entry {
-	char *name;
-	size_t field_offset;
-};
-
-static const struct applespi_acpi_map_entry applespi_spi_settings_map[] = {
-	{ "spiSclkPeriod", offsetof(struct spi_settings, spi_sclk_period) },
-	{ "spiWordSize",   offsetof(struct spi_settings, spi_word_size) },
-	{ "spiBitOrder",   offsetof(struct spi_settings, spi_bit_order) },
-	{ "spiSPO",        offsetof(struct spi_settings, spi_spo) },
-	{ "spiSPH",        offsetof(struct spi_settings, spi_sph) },
-	{ "spiCSDelay",    offsetof(struct spi_settings, spi_cs_delay) },
-	{ "resetA2RUsec",  offsetof(struct spi_settings, reset_a2r_usec) },
-	{ "resetRecUsec",  offsetof(struct spi_settings, reset_rec_usec) },
-};
-
-static u8 *acpi_dsm_uuid = "a0b5b7c6-1318-441c-b0c9-fe695eaf949b";
-
-static int applespi_find_settings_field(const char *name)
-{
-	int i;
-
-	for (i = 0; i < ARRAY_SIZE(applespi_spi_settings_map); i++) {
-		if (strcmp(applespi_spi_settings_map[i].name, name) == 0)
-			return applespi_spi_settings_map[i].field_offset;
-	}
-
-	return -1;
-}
-
-static int applespi_get_spi_settings(acpi_handle handle,
-				     struct spi_settings *settings)
-{
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 13, 0)
-	guid_t guid, *uuid = &guid;
-#else
-	u8 uuid[16];
-#endif
-	union acpi_object *spi_info;
-	union acpi_object name;
-	union acpi_object value;
-	int i;
-	int field_off;
-	u64 *field;
-
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 13, 0)
-	guid_parse(acpi_dsm_uuid, uuid);
-#else
-	acpi_str_to_uuid(acpi_dsm_uuid, uuid);
-#endif
-
-	spi_info = acpi_evaluate_dsm(handle, uuid, 1, 1, NULL);
-	if (!spi_info) {
-		pr_err("Failed to get SPI info from _DSM method\n");
-		return -ENODEV;
-	}
-	if (spi_info->type != ACPI_TYPE_PACKAGE) {
-		pr_err("Unexpected data returned from SPI _DSM method: type=%d\n",
-		       spi_info->type);
-		ACPI_FREE(spi_info);
-		return -ENODEV;
-	}
-
-	/*
-	 * The data is stored in pairs of items, first a string containing
-	 * the name of the item, followed by an 8-byte buffer containing the
-	 * value in little-endian.
-	 */
-	for (i = 0; i < spi_info->package.count - 1; i += 2) {
-		name = spi_info->package.elements[i];
-		value = spi_info->package.elements[i + 1];
-
-		if (!(name.type == ACPI_TYPE_STRING &&
-		      value.type == ACPI_TYPE_BUFFER &&
-		      value.buffer.length == 8)) {
-			pr_warn("Unexpected data returned from SPI _DSM method: name.type=%d, value.type=%d\n",
-				name.type, value.type);
-			continue;
-		}
-
-		field_off = applespi_find_settings_field(name.string.pointer);
-		if (field_off < 0) {
-			pr_debug("Skipping unknown SPI setting '%s'\n",
-				 name.string.pointer);
-			continue;
-		}
-
-		field = (u64 *)((char *)settings + field_off);
-		*field = le64_to_cpu(*((__le64 *)value.buffer.pointer));
-	}
-	ACPI_FREE(spi_info);
-
-	return 0;
-}
-
-#else
-
 static int applespi_get_spi_settings(struct applespi_data *applespi)
 {
-	struct acpi_device *adev = ACPI_COMPANION(&applespi->spi->dev);
-	const union acpi_object *o;
-	struct spi_settings *settings = &applespi->spi_settings;
+       struct acpi_device *adev = ACPI_COMPANION(&applespi->spi->dev);
+       const union acpi_object *o;
+       struct spi_settings *settings = &applespi->spi_settings;
 
 	if (!acpi_dev_get_property(adev, "spiCSDelay", ACPI_TYPE_BUFFER, &o))
 		settings->spi_cs_delay = *(u64 *)o->buffer.pointer;
@@ -862,21 +750,11 @@ static int applespi_get_spi_settings(struct applespi_data *applespi)
 	return 0;
 }
 
-#endif
-
-static int applespi_setup_spi(struct applespi_data *applespi
-#ifdef PRE_SPI_PROPERTIES
-			      , acpi_handle spi_handle
-#endif
-			      )
+static int applespi_setup_spi(struct applespi_data *applespi)
 {
 	int sts;
 
-#ifdef PRE_SPI_PROPERTIES
-	sts = applespi_get_spi_settings(spi_handle, &applespi->spi_settings);
-#else
 	sts = applespi_get_spi_settings(applespi);
-#endif
 	if (sts)
 		return sts;
 
@@ -1919,12 +1797,8 @@ static int applespi_probe(struct spi_device *spi)
 		return -ENODEV;
 	}
 
-	/* switch on the SPI interface */
-	sts = applespi_setup_spi(applespi
-#ifdef PRE_SPI_PROPERTIES
-				 , spi_handle
-#endif
-				 );
+       /* switch on the SPI interface */
+       sts = applespi_setup_spi(applespi);
 	if (sts)
 		return sts;
 
@@ -2223,405 +2097,7 @@ static struct spi_driver applespi_driver = {
 	.shutdown	= applespi_shutdown,
 };
 
-#ifdef PRE_SPI_PROPERTIES
-
-#define SPI_DEV_CHIP_SEL	0	/* from DSDT UBUF */
-
-/*
- * All the following code is to deal with the fact that the _CRS method for
- * the SPI device in the DSDT returns an empty resource, and the real info is
- * available from the _DSM method. So we need to hook into the ACPI device
- * registration and create and register the SPI device ourselves.
- *
- * All of this can be removed and replaced with
- * module_spi_driver(applespi_driver)
- * when the core adds support for this sort of setup.
- */
-
-/*
- * Configure the spi device with the info from the _DSM method.
- */
-static int appleacpi_config_spi_dev(struct spi_device *spi,
-				    struct acpi_device *adev)
-{
-	struct spi_settings settings;
-	int ret;
-
-	ret = applespi_get_spi_settings(acpi_device_handle(adev), &settings);
-	if (ret)
-		return ret;
-
-	spi->max_speed_hz = 1000000000 / settings.spi_sclk_period;
-	spi->chip_select = SPI_DEV_CHIP_SEL;
-	spi->bits_per_word = settings.spi_word_size;
-
-	spi->mode =
-		(settings.spi_spo * SPI_CPOL) |
-		(settings.spi_sph * SPI_CPHA) |
-		(settings.spi_bit_order == 0 ? SPI_LSB_FIRST : 0);
-
-	spi->irq = -1;		/* uses GPE */
-
-	spi->dev.platform_data = NULL;
-	spi->controller_data = NULL;
-	spi->controller_state = NULL;
-
-	pr_debug("spi-config: max_speed_hz=%d, chip_select=%d, bits_per_word=%d, mode=%x, irq=%d\n",
-		 spi->max_speed_hz, spi->chip_select, spi->bits_per_word,
-		 spi->mode, spi->irq);
-
-	return 0;
-}
-
-static int appleacpi_is_device_registered(struct device *dev, void *data)
-{
-	struct spi_device *spi = to_spi_device(dev);
-	struct spi_master *spi_master = data;
-
-	if (spi->master == spi_master && spi->chip_select == SPI_DEV_CHIP_SEL)
-		return -EBUSY;
-	return 0;
-}
-
-/*
- * Unregister all physical devices devices associated with the acpi device,
- * so that the new SPI device becomes the first physical device for it.
- * Otherwise we don't get properly registered as the driver for the spi
- * device.
- */
-static void appleacpi_unregister_phys_devs(struct acpi_device *adev)
-{
-	struct acpi_device_physical_node *entry;
-	struct device *dev;
-
-	while (true) {
-		mutex_lock(&adev->physical_node_lock);
-
-		if (list_empty(&adev->physical_node_list)) {
-			mutex_unlock(&adev->physical_node_lock);
-			break;
-		}
-
-		entry = list_first_entry(&adev->physical_node_list,
-					 struct acpi_device_physical_node,
-					 node);
-		dev = get_device(entry->dev);
-
-		mutex_unlock(&adev->physical_node_lock);
-
-		platform_device_unregister(to_platform_device(dev));
-		put_device(dev);
-	}
-}
-
-/*
- * Create the spi device for the keyboard and touchpad and register it with
- * the master spi device.
- */
-static int appleacpi_register_spi_device(struct spi_master *spi_master,
-					 struct acpi_device *adev)
-{
-	struct appleacpi_spi_registration_info *reg_info;
-	struct spi_device *spi;
-	int ret;
-
-	reg_info = acpi_driver_data(adev);
-
-	/* check if an spi device is already registered */
-	ret = bus_for_each_dev(&spi_bus_type, NULL, spi_master,
-			       appleacpi_is_device_registered);
-	if (ret == -EBUSY) {
-		pr_info("Spi Device already registered - patched DSDT?\n");
-		ret = 0;
-		goto release_master;
-	} else if (ret) {
-		pr_err("Error checking for spi device registered: %d\n", ret);
-		goto release_master;
-	}
-
-	/* none is; check if acpi device is there */
-	if (acpi_bus_get_status(adev) || !adev->status.present) {
-		pr_info("ACPI device is not present\n");
-		ret = 0;
-		goto release_master;
-	}
-
-	/*
-	 * acpi device is there.
-	 *
-	 * First unregister any physical devices already associated with this
-	 * acpi device (done by acpi_generic_device_attach).
-	 */
-	appleacpi_unregister_phys_devs(adev);
-
-	/* create spi device */
-	spi = spi_alloc_device(spi_master);
-	if (!spi) {
-		pr_err("Failed to allocate spi device\n");
-		ret = -ENOMEM;
-		goto release_master;
-	}
-
-	ret = appleacpi_config_spi_dev(spi, adev);
-	if (ret)
-		goto free_spi;
-
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
-	acpi_set_modalias(adev, acpi_device_hid(adev), spi->modalias,
-			  sizeof(spi->modalias));
-#else
-	strlcpy(spi->modalias, acpi_device_hid(adev), sizeof(spi->modalias));
-#endif
-
-	adev->power.flags.ignore_parent = true;
-
-	ACPI_COMPANION_SET(&spi->dev, adev);
-	acpi_device_set_enumerated(adev);
-
-	/* add spi device */
-	ret = spi_add_device(spi);
-	if (ret) {
-		adev->power.flags.ignore_parent = false;
-		pr_err("Failed to add spi device: %d\n", ret);
-		goto free_spi;
-	}
-
-	reg_info->spi = spi;
-
-	pr_info("Added spi device %s\n", dev_name(&spi->dev));
-
-	goto release_master;
-
-free_spi:
-	spi_dev_put(spi);
-release_master:
-	spi_master_put(spi_master);
-	reg_info->spi_master = NULL;
-
-	return ret;
-}
-
-static void appleacpi_dev_registration_worker(struct work_struct *work)
-{
-	struct appleacpi_spi_registration_info *info =
-		container_of(work, struct appleacpi_spi_registration_info,
-			     work.work);
-
-	if (info->spi_master && !info->spi_master->running) {
-		pr_debug_ratelimited("spi-master device is not running yet\n");
-		schedule_delayed_work(&info->work, usecs_to_jiffies(100));
-		return;
-	}
-
-	appleacpi_register_spi_device(info->spi_master, info->adev);
-}
-
-/*
- * Callback for whenever a new master spi device is added.
- */
-static int appleacpi_spi_master_added(struct device *dev,
-				      struct class_interface *cif)
-{
-	struct spi_master *spi_master =
-		container_of(dev, struct spi_master, dev);
-	struct appleacpi_spi_registration_info *info =
-		container_of(cif, struct appleacpi_spi_registration_info, cif);
-	struct acpi_device *master_adev = spi_master->dev.parent ?
-		ACPI_COMPANION(spi_master->dev.parent) : NULL;
-
-	pr_debug("New spi-master device %s (%s) with bus-number %d was added\n",
-		 dev_name(&spi_master->dev),
-		 master_adev ? acpi_device_hid(master_adev) : "-no-acpi-dev-",
-		 spi_master->bus_num);
-
-	if (master_adev != info->adev->parent)
-		return 0;
-
-	pr_info("Got spi-master device for device %s\n",
-		acpi_device_hid(info->adev));
-
-	/*
-	 * mutexes are held here, preventing unregistering of physical devices,
-	 * so need to do the actual registration in a worker.
-	 */
-	info->spi_master = spi_master_get(spi_master);
-	schedule_delayed_work(&info->work, usecs_to_jiffies(100));
-
-	return 0;
-}
-
-/*
- * Callback for whenever a slave spi device is added or removed.
- */
-static int appleacpi_spi_slave_changed(struct notifier_block *nb,
-				       unsigned long action, void *data)
-{
-	struct appleacpi_spi_registration_info *info =
-		container_of(nb, struct appleacpi_spi_registration_info,
-			     slave_notifier);
-	struct spi_device *spi = data;
-
-	pr_debug("SPI slave device changed: action=%lu, dev=%s\n",
-		 action, dev_name(&spi->dev));
-
-	switch (action) {
-	case BUS_NOTIFY_DEL_DEVICE:
-		if (spi == info->spi) {
-			info->spi = NULL;
-			return NOTIFY_OK;
-		}
-		break;
-
-	default:
-		break;
-	}
-
-	return NOTIFY_DONE;
-}
-
-/*
- * spi_master_class is not exported, so this is an ugly hack to get it anyway.
- */
-static struct class *appleacpi_get_spi_master_class(void)
-{
-	struct spi_master *spi_master;
-	struct device dummy;
-	struct class *cls = NULL;
-
-	memset(&dummy, 0, sizeof(dummy));
-
-	spi_master = spi_alloc_master(&dummy, 0);
-	if (spi_master) {
-		cls = spi_master->dev.class;
-		spi_master_put(spi_master);
-	}
-
-	return cls;
-}
-
-static int appleacpi_probe(struct acpi_device *adev)
-{
-	struct appleacpi_spi_registration_info *reg_info;
-	int ret;
-
-	pr_debug("Probing acpi-device %s: bus-id='%s', adr=%lu, uid='%s'\n",
-		 acpi_device_hid(adev), acpi_device_bid(adev),
-		 acpi_device_adr(adev), acpi_device_uid(adev));
-
-	ret = spi_register_driver(&applespi_driver);
-	if (ret) {
-		pr_err("Failed to register spi-driver: %d\n", ret);
-		return ret;
-	}
-
-	/*
-	 * Ideally we would just call spi_register_board_info() here,
-	 * but that function is not exported. Additionally, we need to
-	 * perform some extra work during device creation, such as
-	 * unregistering physical devices. So instead we have do the
-	 * registration ourselves. For that we see if our spi-master
-	 * has been registered already, and if not jump through some
-	 * hoops to make sure we are notified when it does.
-	 */
-
-	reg_info = kzalloc(sizeof(*reg_info), GFP_KERNEL);
-	if (!reg_info) {
-		ret = -ENOMEM;
-		goto unregister_driver;
-	}
-
-	reg_info->adev = adev;
-	INIT_DELAYED_WORK(&reg_info->work, appleacpi_dev_registration_worker);
-
-	adev->driver_data = reg_info;
-
-	/*
-	 * Set up listening for spi slave removals so we can properly
-	 * handle them.
-	 */
-	reg_info->slave_notifier.notifier_call =
-		appleacpi_spi_slave_changed;
-	ret = bus_register_notifier(&spi_bus_type,
-				    &reg_info->slave_notifier);
-	if (ret) {
-		pr_err("Failed to register notifier for spi slaves: %d\n", ret);
-		goto free_reg_info;
-	}
-
-	/*
-	 * Listen for additions of spi-master devices so we can register our spi
-	 * device when the relevant master is added.  Note that our callback
-	 * gets called immediately for all existing master devices, so this
-	 * takes care of registration when the master already exists too.
-	 */
-	reg_info->cif.class = appleacpi_get_spi_master_class();
-	reg_info->cif.add_dev = appleacpi_spi_master_added;
-
-	ret = class_interface_register(&reg_info->cif);
-	if (ret) {
-		pr_err("Failed to register watcher for spi-master: %d\n", ret);
-		goto unregister_notifier;
-	}
-
-	if (!reg_info->spi_master) {
-		pr_info("No spi-master device found for device %s - waiting for it to be registered\n",
-			acpi_device_hid(adev));
-	}
-
-	pr_info("acpi-device probe done: %s\n", acpi_device_hid(adev));
-
-	return 0;
-
-unregister_notifier:
-	bus_unregister_notifier(&spi_bus_type, &reg_info->slave_notifier);
-free_reg_info:
-	adev->driver_data = NULL;
-	kfree(reg_info);
-unregister_driver:
-	spi_unregister_driver(&applespi_driver);
-	return ret;
-}
-
-static int appleacpi_remove(struct acpi_device *adev)
-{
-	struct appleacpi_spi_registration_info *reg_info;
-
-	reg_info = acpi_driver_data(adev);
-	if (reg_info) {
-		class_interface_unregister(&reg_info->cif);
-		bus_unregister_notifier(&spi_bus_type,
-					&reg_info->slave_notifier);
-		cancel_delayed_work_sync(&reg_info->work);
-		if (reg_info->spi)
-			spi_unregister_device(reg_info->spi);
-		kfree(reg_info);
-	}
-
-	spi_unregister_driver(&applespi_driver);
-
-	pr_info("acpi-device remove done: %s\n", acpi_device_hid(adev));
-
-	return 0;
-}
-
-static struct acpi_driver appleacpi_driver = {
-	.name		= "appleacpi",
-	.class		= "topcase", /* ? */
-	.owner		= THIS_MODULE,
-	.ids		= applespi_acpi_match,
-	.ops		= {
-		.add		= appleacpi_probe,
-		.remove		= appleacpi_remove,
-	},
-};
-
-module_acpi_driver(appleacpi_driver)
-
-#else
-
-module_spi_driver(applespi_driver)
-
-#endif
+module_spi_driver(applespi_driver);
 
 MODULE_LICENSE("GPL v2");
 MODULE_IMPORT_NS(EFIVAR);

--- a/applespi.c
+++ b/applespi.c
@@ -587,7 +587,8 @@ static void applespi_setup_read_txfrs(struct applespi_data *applespi)
 	memset(dl_t, 0, sizeof(*dl_t));
 	memset(rd_t, 0, sizeof(*rd_t));
 
-	dl_t->delay_usecs = applespi->spi_settings.spi_cs_delay;
+        dl_t->delay.value = applespi->spi_settings.spi_cs_delay;
+        dl_t->delay.unit = SPI_DELAY_UNIT_USECS;
 
 	rd_t->rx_buf = applespi->rx_buffer;
 	rd_t->len = APPLESPI_PACKET_SIZE;
@@ -616,14 +617,17 @@ static void applespi_setup_write_txfrs(struct applespi_data *applespi)
 	 * end up with an extra unnecessary (but harmless) cs assertion and
 	 * deassertion.
 	 */
-	wt_t->delay_usecs = SPI_RW_CHG_DELAY_US;
+        wt_t->delay.value = SPI_RW_CHG_DELAY_US;
+        wt_t->delay.unit = SPI_DELAY_UNIT_USECS;
 	wt_t->cs_change = 1;
 
-	dl_t->delay_usecs = applespi->spi_settings.spi_cs_delay;
+        dl_t->delay.value = applespi->spi_settings.spi_cs_delay;
+        dl_t->delay.unit = SPI_DELAY_UNIT_USECS;
 
-	wr_t->tx_buf = applespi->tx_buffer;
-	wr_t->len = APPLESPI_PACKET_SIZE;
-	wr_t->delay_usecs = SPI_RW_CHG_DELAY_US;
+        wr_t->tx_buf = applespi->tx_buffer;
+        wr_t->len = APPLESPI_PACKET_SIZE;
+        wr_t->delay.value = SPI_RW_CHG_DELAY_US;
+        wr_t->delay.unit = SPI_DELAY_UNIT_USECS;
 
 	st_t->rx_buf = applespi->tx_status;
 	st_t->len = APPLESPI_STATUS_SIZE;
@@ -1786,52 +1790,44 @@ static u32 applespi_notify(acpi_handle gpe_device, u32 gpe, void *context)
 
 static int applespi_get_saved_bl_level(struct applespi_data *applespi)
 {
-	struct efivar_entry *efivar_entry;
-	u16 efi_data = 0;
-	unsigned long efi_data_len;
-	int sts;
+        unsigned long efi_data_len = sizeof(u16);
+        u16 efi_data = 0;
+        u32 efi_attr;
+        efi_guid_t efi_guid = EFI_BL_LEVEL_GUID;
+        efi_status_t status;
+        int err;
 
-	efivar_entry = kmalloc(sizeof(*efivar_entry), GFP_KERNEL);
-	if (!efivar_entry)
-		return -ENOMEM;
+        status = efivar_get_variable((efi_char16_t *)EFI_BL_LEVEL_NAME,
+                                     &efi_guid, &efi_attr, &efi_data_len,
+                                     &efi_data);
+        err = efi_status_to_err(status);
+        if (err && err != -ENOENT)
+                dev_warn(&applespi->spi->dev,
+                         "Error getting backlight level from EFI vars: %d\n",
+                         err);
 
-	memcpy(efivar_entry->var.VariableName, EFI_BL_LEVEL_NAME,
-	       sizeof(EFI_BL_LEVEL_NAME));
-	efivar_entry->var.VendorGuid = EFI_BL_LEVEL_GUID;
-	efi_data_len = sizeof(efi_data);
-
-	sts = efivar_entry_get(efivar_entry, NULL, &efi_data_len, &efi_data);
-	if (sts && sts != -ENOENT)
-		dev_warn(&applespi->spi->dev,
-			 "Error getting backlight level from EFI vars: %d\n",
-			 sts);
-
-	kfree(efivar_entry);
-
-	return sts ? sts : efi_data;
+        return err ? err : efi_data;
 }
 
 static void applespi_save_bl_level(struct applespi_data *applespi,
-				   unsigned int level)
+                                   unsigned int level)
 {
-	efi_guid_t efi_guid;
-	u32 efi_attr;
-	unsigned long efi_data_len;
-	u16 efi_data;
-	int sts;
+        efi_guid_t efi_guid = EFI_BL_LEVEL_GUID;
+        unsigned long efi_data_len = sizeof(u16);
+        u16 efi_data = (u16)level;
+        u32 efi_attr = EFI_VARIABLE_NON_VOLATILE |
+                       EFI_VARIABLE_BOOTSERVICE_ACCESS |
+                       EFI_VARIABLE_RUNTIME_ACCESS;
+        efi_status_t status;
+        int err;
 
-	/* Save keyboard backlight level */
-	efi_guid = EFI_BL_LEVEL_GUID;
-	efi_data = (u16)level;
-	efi_data_len = sizeof(efi_data);
-	efi_attr = EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_BOOTSERVICE_ACCESS |
-		   EFI_VARIABLE_RUNTIME_ACCESS;
-
-	sts = efivar_entry_set_safe((efi_char16_t *)EFI_BL_LEVEL_NAME, efi_guid,
-				    efi_attr, true, efi_data_len, &efi_data);
-	if (sts)
-		dev_warn(&applespi->spi->dev,
-			 "Error saving backlight level to EFI vars: %d\n", sts);
+        status = efivar_set_variable((efi_char16_t *)EFI_BL_LEVEL_NAME,
+                                     &efi_guid, efi_attr,
+                                     efi_data_len, &efi_data);
+        err = efi_status_to_err(status);
+        if (err)
+                dev_warn(&applespi->spi->dev,
+                         "Error saving backlight level to EFI vars: %d\n", err);
 }
 
 static void applespi_enable_early_event_tracing(struct device *dev)
@@ -2109,9 +2105,9 @@ static void applespi_drain_reads(struct applespi_data *applespi)
 	spin_unlock_irqrestore(&applespi->cmd_msg_lock, flags);
 }
 
-static int applespi_remove(struct spi_device *spi)
+static void applespi_remove(struct spi_device *spi)
 {
-	struct applespi_data *applespi = spi_get_drvdata(spi);
+        struct applespi_data *applespi = spi_get_drvdata(spi);
 
 	applespi_drain_writes(applespi);
 
@@ -2121,9 +2117,7 @@ static int applespi_remove(struct spi_device *spi)
 
 	applespi_drain_reads(applespi);
 
-	debugfs_remove_recursive(applespi->debugfs_root);
-
-	return 0;
+        debugfs_remove_recursive(applespi->debugfs_root);
 }
 
 static void applespi_shutdown(struct spi_device *spi)
@@ -2630,6 +2624,7 @@ module_spi_driver(applespi_driver)
 #endif
 
 MODULE_LICENSE("GPL v2");
+MODULE_IMPORT_NS(EFIVAR);
 MODULE_DESCRIPTION("MacBook(Pro) SPI Keyboard/Touchpad driver");
 MODULE_AUTHOR("Federico Lorenzi");
 MODULE_AUTHOR("Ronald Tschalär");


### PR DESCRIPTION
## Summary
- update SPI module for modern kernel API
- update HID bridge and Touch Bar modules for new driver callbacks
- adapt ALS driver to current IIO APIs
- import EFIVAR namespace for EFI variable functions
- fix cleanup callbacks and driver allocation

## Testing
- `make KVERSION=6.11.0-26-generic` *(fails: `/lib/modules/6.11.0-26-generic/build: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_685101775e04832189e8fd000090b795