### PR TITLE
Update driver for Linux 5.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@ Input driver for the SPI keyboard / trackpad found on 12" MacBooks (2015 and lat
 
 The keyboard / trackpad driver here is now included in the kernel as of v5.3.
 
+This out-of-tree repository remains useful for additional MacBook devices and
+is now updated to build against Linux kernels up to version 5.15.
+
 NOTE:
 -----
 The touchbar driver was refactored in late 2018; if you're upgrading from the `appletb` driver, please see the [Upgrading](#upgrading) section; if you're running a kernel before 4.16 then please check out the [legacy](../../tree/touchbar-driver-monolithic) branch instead.

--- a/apple-ib-als.c
+++ b/apple-ib-als.c
@@ -460,7 +460,8 @@ static int appleals_config_iio(struct appleals_device *als_dev)
 	struct appleals_device **priv;
 	int rc;
 
-	iio_dev = iio_device_alloc(sizeof(als_dev));
+       iio_dev = iio_device_alloc(&als_dev->hid_dev->dev,
+                                  sizeof(als_dev));
 	if (!iio_dev)
 		return -ENOMEM;
 
@@ -482,7 +483,8 @@ static int appleals_config_iio(struct appleals_device *als_dev)
 		goto free_iio_dev;
 	}
 
-	iio_trig = iio_trigger_alloc("%s-dev%d", iio_dev->name, iio_dev->id);
+       iio_trig = iio_trigger_alloc(&als_dev->hid_dev->dev,
+                                   "%s-dev0", iio_dev->name);
 	if (!iio_trig) {
 		rc = -ENOMEM;
 		goto clean_trig_buf;

--- a/applespi.c
+++ b/applespi.c
@@ -587,7 +587,8 @@ static void applespi_setup_read_txfrs(struct applespi_data *applespi)
 	memset(dl_t, 0, sizeof(*dl_t));
 	memset(rd_t, 0, sizeof(*rd_t));
 
-	dl_t->delay_usecs = applespi->spi_settings.spi_cs_delay;
+       dl_t->delay.value = applespi->spi_settings.spi_cs_delay;
+       dl_t->delay.unit = SPI_DELAY_UNIT_USECS;
 
 	rd_t->rx_buf = applespi->rx_buffer;
 	rd_t->len = APPLESPI_PACKET_SIZE;
@@ -616,14 +617,17 @@ static void applespi_setup_write_txfrs(struct applespi_data *applespi)
 	 * end up with an extra unnecessary (but harmless) cs assertion and
 	 * deassertion.
 	 */
-	wt_t->delay_usecs = SPI_RW_CHG_DELAY_US;
+       wt_t->delay.value = SPI_RW_CHG_DELAY_US;
+       wt_t->delay.unit = SPI_DELAY_UNIT_USECS;
 	wt_t->cs_change = 1;
 
-	dl_t->delay_usecs = applespi->spi_settings.spi_cs_delay;
+       dl_t->delay.value = applespi->spi_settings.spi_cs_delay;
+       dl_t->delay.unit = SPI_DELAY_UNIT_USECS;
 
 	wr_t->tx_buf = applespi->tx_buffer;
 	wr_t->len = APPLESPI_PACKET_SIZE;
-	wr_t->delay_usecs = SPI_RW_CHG_DELAY_US;
+       wr_t->delay.value = SPI_RW_CHG_DELAY_US;
+       wr_t->delay.unit = SPI_DELAY_UNIT_USECS;
 
 	st_t->rx_buf = applespi->tx_status;
 	st_t->len = APPLESPI_STATUS_SIZE;
@@ -2109,7 +2113,11 @@ static void applespi_drain_reads(struct applespi_data *applespi)
 	spin_unlock_irqrestore(&applespi->cmd_msg_lock, flags);
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+static void applespi_remove(struct spi_device *spi)
+#else
 static int applespi_remove(struct spi_device *spi)
+#endif
 {
 	struct applespi_data *applespi = spi_get_drvdata(spi);
 
@@ -2121,9 +2129,10 @@ static int applespi_remove(struct spi_device *spi)
 
 	applespi_drain_reads(applespi);
 
-	debugfs_remove_recursive(applespi->debugfs_root);
-
-	return 0;
+       debugfs_remove_recursive(applespi->debugfs_root);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
+       return 0;
+#endif
 }
 
 static void applespi_shutdown(struct spi_device *spi)


### PR DESCRIPTION
## Summary
- adapt SPI transfer delays to new struct spi_delay API
- fix remove callback prototype for kernels after 6.1
- update ALS driver to new IIO allocation & trigger APIs

## Testing
- `make KVERSION=5.15.0-139-generic`


------
https://chatgpt.com/codex/tasks/task_e_68512a1c8ce48321808c25ec1df82711